### PR TITLE
Base client fixes

### DIFF
--- a/lib/pusher-platform/base_client.rb
+++ b/lib/pusher-platform/base_client.rb
@@ -28,11 +28,14 @@ module Pusher
         headers["Authorization"] = "Bearer #{options[:jwt]}"
       end
 
+      path = "services/#{@service_name}/#{@service_version}/#{@instance_id}/#{options[:path]}"
+      body = options[:body].any? ? options[:body].to_json : nil
+
       response = @connection.request(
         method: options[:method],
-        path: "services/#{@service_name}/#{@service_version}/#{@instance_id}/#{options[:path]}",
+        path: sanitise_path(path),
         headers: headers,
-        body: options[:body],
+        body: body,
       )
 
       if response.status >= 200 && response.status <= 299
@@ -49,6 +52,12 @@ module Pusher
       else
         raise "unsupported response code: #{response.status}"
       end
+    end
+
+    private
+
+    def sanitise_path(path)
+      path.gsub(/\/+/, "/").gsub(/\/+$/, "")
     end
   end
 end

--- a/lib/pusher-platform/instance.rb
+++ b/lib/pusher-platform/instance.rb
@@ -44,7 +44,6 @@ module Pusher
     end
 
     def request(options)
-      options = scope_request_options(options)
       if options[:jwt].nil?
         options = options.merge(
           { jwt: @authenticator.generate_access_token({ su: true })[:token] }
@@ -60,15 +59,5 @@ module Pusher
     def generate_access_token(options)
       @authenticator.generate_access_token(options)
     end
-
-    private
-
-    def scope_request_options(options)
-      path = options[:path]
-        .gsub(/\/+/, "/")
-        .gsub(/\/+$/, "")
-      options.merge({ path: path })
-    end
-
   end
 end


### PR DESCRIPTION
### What?

Sanitise the entire request path
Make sure request bodies are JSONised if they exist

#### Why?

Previously the library only sanitised the path provided in the options, but the client added a `/` before interpolating it, which means, there could still be a double `/` in the request path.

Request bodies were previously required to be passed in as JSON, but this could be done in the base client itself, if a body is provided.

#### How?

Remove the sanitisation method in the `instance.rb` file and move it to the `base_client.rb` file. Construct the entire request path and then sanitise it.

Check if there is a request body and if there is one, then JSONise it.

----

CC @pusher/sigsdk