### PR TITLE
Support query params

### DIFF
--- a/lib/pusher-platform/base_client.rb
+++ b/lib/pusher-platform/base_client.rb
@@ -38,6 +38,7 @@ module Pusher
         path: sanitise_path(path),
         headers: headers,
         body: body,
+        query: options[:query]
       )
 
       if response.status >= 200 && response.status <= 299


### PR DESCRIPTION
### What?

Chatkit server library requires support for query strings. I could add the query param conditionally, but I assume it will be ignored or not set if the param is `nil`

#### Why?

...

#### How?

...

----

CC @pusher/sigsdk
