### PR TITLE
token: app -> instance

### DIFF
--- a/example/test.rb
+++ b/example/test.rb
@@ -1,6 +1,6 @@
 require_relative '../lib/pusher'
 
-authorizer = Pusher::Authorizer.new("app_id", "ISSUER1:S3CR3T")
+authorizer = Pusher::Authorizer.new("instance_id", "ISSUER1:S3CR3T")
 
 payload = authorizer.authorize_credentials("12313")
 puts payload

--- a/lib/pusher-platform/authenticator.rb
+++ b/lib/pusher-platform/authenticator.rb
@@ -37,7 +37,7 @@ module Pusher
       now = Time.now.utc.to_i
 
       claims = {
-        app: @instance_id,
+        instance: @instance_id,
         iss: "api_keys/#{@key_id}",
         iat: now - TOKEN_LEEWAY,
         exp: now + TOKEN_EXPIRY - TOKEN_LEEWAY # TODO: Change to + TOKEN_LEEWAY soon, but for now max exp is 86400
@@ -121,7 +121,7 @@ module Pusher
       now = Time.now.utc.to_i
 
       claims = {
-        app: @instance_id,
+        instance: @instance_id,
         iss: "api_keys/#{@key_id}",
         iat: now - TOKEN_LEEWAY,
         refresh: true,


### PR DESCRIPTION
Migrates to using the `instance` claim instead of the `app` claim in tokens, and also cleans up any remaining references to app IDs

----

CC @pusher/sigsdk
