### PR TITLE
Don't auto-generate a JWT with su: true claim if no JWT provided to Instance.request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/pusher-platform-ruby/compare/0.8.2...HEAD)
+## [Unreleased](https://github.com/pusher/pusher-platform-ruby/compare/0.9.0...HEAD)
+
+## [0.9.0](https://github.com/pusher/pusher-platform-ruby/compare/0.8.2...0.9.0) - 2018-09-12
+
+### Changes
+
+- Removed defaulting to generating a JWT with the `su: true` claim if no JWT is provided to a call to `request`
 
 ## [0.8.2](https://github.com/pusher/pusher-platform-ruby/compare/0.8.1...0.8.2) - 2018-07-20
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Pusher Platform SDK for Ruby.
 Add `pusher-platform` to your Gemfile:
 
 ```
-gem 'pusher-platform', '~> 0.8.2'
+gem 'pusher-platform', '~> 0.9.0'
 ```
 
 ## Usage

--- a/lib/pusher-platform/instance.rb
+++ b/lib/pusher-platform/instance.rb
@@ -44,11 +44,6 @@ module PusherPlatform
     end
 
     def request(options)
-      if options[:jwt].nil?
-        options = options.merge(
-          { jwt: @authenticator.generate_access_token({ su: true })[:token] }
-        )
-      end
       @client.request(options)
     end
 

--- a/pusher_platform.gemspec
+++ b/pusher_platform.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'pusher-platform'
-  s.version     = '0.8.2'
+  s.version     = '0.9.0'
   s.licenses    = ['MIT']
   s.summary     = "Pusher Platform Ruby SDK"
   s.authors     = ["Pusher"]


### PR DESCRIPTION
### What?

See title

### Why?

Shouldn't auto-generate tokens, especially not with su: true claim

----

- [ ] README updated if you changed the API?
- [x] CHANGELOG updated if relevant?

----

CC @pusher/sigsdk
