### PR TITLE
SDK info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changes
 
-- An instance of `SDKInfo` is now required when instantiating an instance of `BaseClient`. This can either be directly provided to the `BaseClient` and then the base client provided to an instance of `Instance` in the `client` key or the `options` object that `Instance`s initializer takes, or you can provide the `SDKInfo` instance to the `Instance` initializer in the `sdk_info` key of its `options` parameter
+- *Breaking* An instance of `SDKInfo` is now required when instantiating an instance of `BaseClient`. This can either be directly provided to the `BaseClient` and then the base client provided to an instance of `Instance` in the `client` key or the `options` object that `Instance`s initializer takes, or you can provide the `SDKInfo` instance to the `Instance` initializer in the `sdk_info` key of its `options` parameter
 
 ## [0.10.0](https://github.com/pusher/pusher-platform-ruby/compare/0.9.0...0.10.0) - 2018-09-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/pusher-platform-ruby/compare/0.10.0...HEAD)
 
+### Changes
+
+- An instance of `SDKInfo` is now required when instantiating an instance of `BaseClient`. This can either be directly provided to the `BaseClient` and then the base client provided to an instance of `Instance` in the `client` key or the `options` object that `Instance`s initializer takes, or you can provide the `SDKInfo` instance to the `Instance` initializer in the `sdk_info` key of its `options` parameter
+
 ## [0.10.0](https://github.com/pusher/pusher-platform-ruby/compare/0.9.0...0.10.0) - 2018-09-17
 
 ### Changes

--- a/examples/chatkit.rb
+++ b/examples/chatkit.rb
@@ -5,7 +5,11 @@ instance = PusherPlatform::Instance.new(
   locator: 'your:instance:locator',
   key: 'your:key',
   service_name: 'chatkit',
-  service_version: 'v1'
+  service_version: 'v1',
+  sdk_info: PusherPlatform::SDKInfo.new(
+    product_name: 'chatkit',
+    version: '0.0.1'
+  )
 )
 
 # We need a su token to create a Chatkit user

--- a/examples/feeds.rb
+++ b/examples/feeds.rb
@@ -5,7 +5,11 @@ instance = PusherPlatform::Instance.new(
   locator: 'your:instance:locator',
   key: 'your:key',
   service_name: 'feeds',
-  service_version: 'v1'
+  service_version: 'v1',
+  sdk_info: PusherPlatform::SDKInfo.new(
+    product_name: 'feeds',
+    version: '0.0.1'
+  )
 )
 
 server_token_claims = {

--- a/lib/pusher-platform/base_client.rb
+++ b/lib/pusher-platform/base_client.rb
@@ -1,5 +1,6 @@
 require 'excon'
 require 'json'
+require_relative './sdk_info'
 require_relative './error_response'
 require_relative './error'
 
@@ -7,6 +8,7 @@ module PusherPlatform
   class BaseClient
     def initialize(options)
       raise PusherPlatform::Error.new("Unspecified host") if options[:host].nil?
+      raise PusherPlatform::Error.new("Unspecified sdk_info") if options[:sdk_info].nil?
       port_string = options[:port] || ''
       host_string = "https://#{options[:host]}#{port_string}"
       @connection = Excon.new(host_string)
@@ -14,17 +16,16 @@ module PusherPlatform
       @instance_id = options[:instance_id]
       @service_name = options[:service_name]
       @service_version = options[:service_version]
+
+      @sdk_info = options[:sdk_info]
     end
 
     def request(options)
       raise PusherPlatform::Error.new("Unspecified request method") if options[:method].nil?
       raise PusherPlatform::Error.new("Unspecified request path") if options[:path].nil?
 
-      headers = if options[:headers]
-        options[:headers].dup
-      else
-        {}
-      end
+      headers = @sdk_info.headers
+      headers.merge(options[:headers].dup) if options[:headers]
 
       if options[:jwt]
         headers["Authorization"] = "Bearer #{options[:jwt]}"

--- a/lib/pusher-platform/instance.rb
+++ b/lib/pusher-platform/instance.rb
@@ -1,6 +1,7 @@
 require_relative './authenticator'
 require_relative './base_client'
 require_relative './common'
+require_relative './sdk_info'
 require_relative './error_response'
 require_relative './error'
 
@@ -14,6 +15,10 @@ module PusherPlatform
       raise PusherPlatform::Error.new("No key provided") if options[:key].nil?
       raise PusherPlatform::Error.new("No service name provided") if options[:service_name].nil?
       raise PusherPlatform::Error.new("No service version provided") if options[:service_version].nil?
+      if options[:sdk_info].nil? && options[:client].nil?
+        raise PusherPlatform::Error.new("You must provide either an SDKInfo or BaseClient instance via sdk_info or client")
+      end
+
       locator = options[:locator]
       @service_name = options[:service_name]
       @service_version = options[:service_version]
@@ -38,7 +43,8 @@ module PusherPlatform
           port: options[:port],
           instance_id: @instance_id,
           service_name: @service_name,
-          service_version: @service_version
+          service_version: @service_version,
+          sdk_info: options[:sdk_info]
         )
       end
 

--- a/lib/pusher-platform/sdk_info.rb
+++ b/lib/pusher-platform/sdk_info.rb
@@ -1,0 +1,26 @@
+require_relative './error'
+
+module PusherPlatform
+  class SDKInfo
+    attr_reader :product_name, :version, :language, :platform, :headers
+
+    def initialize(options)
+      raise Error.new('No product_name provided to SDKInfo') if options[:product_name].nil?
+      raise Error.new('No version provided to SDKInfo') if options[:version].nil?
+
+      @product_name = options[:product_name]
+      @version = options[:version]
+
+      @platform = options[:platform] || 'server'
+      @language = 'ruby'
+
+      @headers = {
+        "X-SDK-Product" => @product_name,
+        "X-SDK-Version" => @version,
+        "X-SDK-Language" => @language,
+        "X-SDK-Platform" => @platform
+      }
+    end
+
+  end
+end


### PR DESCRIPTION
### What?

Add requirement for SDKInfo to be provided

### Why?

So headers containing SDK information can be sent to services running on the shared platform

----

- [ ] README updated if you changed the API?
- [x] CHANGELOG updated if relevant?

----

CC @pusher/sigsdk
